### PR TITLE
feat: add BAM input support for orthanq preprocessing and configurable HLA alleles

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -7,5 +7,7 @@ Add samples to `config/units.tsv`.
 * Each unit has a `unit_name`. This can be a running number, or an actual run, lane or replicate id (for now this is not functional as we want to make this workflow to comply with the dna-seq-varlociraptor-workflow because we will import this wokrflow as a module there. For that reason, it's not called `samples.tsv`)
 * Each unit has a `sample_name`, which associates it with the biological sample it comes from.
 * For each unit, you need to specify:
-  * `fq1` and `fq2` for paired end reads. These can point to any FASTQ files on your system.
- 
+  * `bam` for using BWA-aligned file.
+  * or,`fq1` and `fq2` for paired end reads. These can point to any FASTQ files on your system.
+
+Please note that the workflow will by default use BAM input if 'bam' column is filled. Otherwise, it will use `fq1` and `fq2` columns.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,4 +1,4 @@
-units: "config/units.tsv"
+orthanq_input: "config/units.tsv"
 
 #tool configurations
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,6 +8,13 @@ orthanq_prior: "uniform"
 #set threads for orthanq preprocessing
 threads: 2
 
+#set which HLA alleles to be predicted (currently only 'A', 'B', 'C' and 'DQB1' are supported.)
+loci:
+  - "A"
+  - "B"
+  - "C"
+  - "DQB1"
+  
 #reference conigurations
 ref:
   # Number of chromosomes to consider for calling.

--- a/config/units.tsv
+++ b/config/units.tsv
@@ -1,1 +1,1 @@
-unit_name	sample_name	fq1	fq2
+unit_name	sample_name	fq1	fq2	bam

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1,16 +1,46 @@
 configfile: "config/config.yaml"
 
+
 include: "rules/common.smk"
 include: "rules/preparation.smk"
-include: "rules/orthanq.smk" 
+include: "rules/orthanq.smk"
+
 
 rule all:
     input:
         # expand("results/orthanq/preprocess/{sample}_{hla}/{sample}.bcf", sample=samples.sample_name, hla=loci),
-        expand("results/orthanq/calls/{sample}_{hla}/{sample}_{hla}.csv", sample=samples.sample_name, hla=loci),
-        expand("results/orthanq/calls/{sample}_{hla}/3_field_solutions.json", sample=samples.sample_name, hla=loci),
-        expand("results/orthanq/calls/{sample}_{hla}/2_field_solutions.json", sample=samples.sample_name, hla=loci),
-        expand("results/orthanq/calls/{sample}_{hla}/final_solution.json", sample=samples.sample_name, hla=loci),
-        expand("results/orthanq/calls/{sample}_{hla}/lp_solution.json", sample=samples.sample_name, hla=loci),
-        expand("results/orthanq/calls/{sample}_{hla}/2-field.csv", sample=samples.sample_name, hla=loci),
-        expand("results/orthanq/calls/{sample}_{hla}/G_groups.csv", sample=samples.sample_name, hla=loci)
+        expand(
+            "results/orthanq/calls/{sample}_{hla}/{sample}_{hla}.csv",
+            sample=samples.sample_name,
+            hla=loci,
+        ),
+        expand(
+            "results/orthanq/calls/{sample}_{hla}/3_field_solutions.json",
+            sample=samples.sample_name,
+            hla=loci,
+        ),
+        expand(
+            "results/orthanq/calls/{sample}_{hla}/2_field_solutions.json",
+            sample=samples.sample_name,
+            hla=loci,
+        ),
+        expand(
+            "results/orthanq/calls/{sample}_{hla}/final_solution.json",
+            sample=samples.sample_name,
+            hla=loci,
+        ),
+        expand(
+            "results/orthanq/calls/{sample}_{hla}/lp_solution.json",
+            sample=samples.sample_name,
+            hla=loci,
+        ),
+        expand(
+            "results/orthanq/calls/{sample}_{hla}/2-field.csv",
+            sample=samples.sample_name,
+            hla=loci,
+        ),
+        expand(
+            "results/orthanq/calls/{sample}_{hla}/G_groups.csv",
+            sample=samples.sample_name,
+            hla=loci,
+        ),

--- a/workflow/envs/orthanq.yaml
+++ b/workflow/envs/orthanq.yaml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - orthanq =1.8.0
+  - orthanq =1.9.1

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -16,8 +16,8 @@ genome_prefix = f"resources/{genome_name}"
 genome = f"{genome_prefix}.fasta"
 genome_fai = f"{genome}.fai"
 
-# list of alleles that will be checked
-loci = ["A","B", "C", "DQA1","DQB1"]
+# list of alleles that will be predicted
+loci = config["loci"]
 
 # read samples
 samples = pd.read_csv(config["orthanq_input"], sep="\t").set_index(

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1,10 +1,12 @@
-
 import pandas as pd
 import os
 
+
 configfile: "config/config.yaml"
 
+
 ruleorder: generate_candidates > preprocess
+
 
 # construct genome name
 datatype_genome = "dna"
@@ -24,16 +26,19 @@ samples = pd.read_csv(config["orthanq_input"], sep="\t").set_index(
     ["sample_name"], drop=False
 )
 
-#The workflow will by default use BAM input if 'bam' column is filled. Otherwise, it will use `fq1` and `fq2` columns.
+
+# The workflow will by default use BAM input if 'bam' column is filled. Otherwise, it will use `fq1` and `fq2` columns.
 def get_fastq_input(wildcards):
     sample = samples.loc[wildcards.sample]
     return [sample["fq1"], sample["fq2"]]
+
 
 def get_orthanq_input(wildcards):
     sample = samples.loc[wildcards.sample]
     if pd.notna(sample.get("bam")) and sample["bam"]:
         return sample["bam"]
     return get_fastq_input(wildcards)
+
 
 def get_orthanq_input_params(wildcards):
     sample = samples.loc[wildcards.sample]

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -20,11 +20,24 @@ genome_fai = f"{genome}.fai"
 loci = ["A","B", "C", "DQA1","DQB1"]
 
 # read samples
-samples = pd.read_csv(config["units"], sep="\t").set_index(
+samples = pd.read_csv(config["orthanq_input"], sep="\t").set_index(
     ["sample_name"], drop=False
 )
 
+#The workflow will by default use BAM input if 'bam' column is filled. Otherwise, it will use `fq1` and `fq2` columns.
 def get_fastq_input(wildcards):
     sample = samples.loc[wildcards.sample]
     return [sample["fq1"], sample["fq2"]]
 
+def get_orthanq_input(wildcards):
+    sample = samples.loc[wildcards.sample]
+    if pd.notna(sample.get("bam")) and sample["bam"]:
+        return sample["bam"]
+    return get_fastq_input(wildcards)
+
+def get_orthanq_input_params(wildcards):
+    sample = samples.loc[wildcards.sample]
+    if pd.notna(sample.get("bam")) and sample["bam"]:
+        return f"--bam-input {sample['bam']}"
+    fq1, fq2 = get_fastq_input(wildcards)
+    return f"--reads {fq1} {fq2}"

--- a/workflow/rules/orthanq.smk
+++ b/workflow/rules/orthanq.smk
@@ -1,4 +1,4 @@
-#wrappers should be used once they are ready
+# wrappers should be used once they are ready
 rule generate_candidates:
     input:
         allele_freq="results/preparation/allele_frequencies.csv",
@@ -6,17 +6,18 @@ rule generate_candidates:
         xml="results/preparation/hla.xml",
         genome=genome,
     output:
-        vcfs=expand("results/candidate_variants/{hla}.vcf", hla=loci)
+        vcfs=expand("results/candidate_variants/{hla}.vcf", hla=loci),
     log:
         "logs/candidates/candidates.log",
     conda:
         "../envs/orthanq.yaml"
     params:
-        output_folder=lambda wc, output: os.path.dirname(output.vcfs[0])
-    benchmark:    
-        "benchmarks/orthanq_candidates/orthanq_candidates.tsv" 
+        output_folder=lambda wc, output: os.path.dirname(output.vcfs[0]),
+    benchmark:
+        "benchmarks/orthanq_candidates/orthanq_candidates.tsv"
     shell:
         "orthanq candidates hla --allele-freq {input.allele_freq} --alleles {input.hla_genes} --genome {input.genome} --xml {input.xml} --output {params.output_folder} 2> {log}"
+
 
 rule preprocess:
     input:
@@ -25,21 +26,23 @@ rule preprocess:
         genome=genome,
         genome_fai=genome_fai,
         pangenome="results/preparation/hprc-v1.0-mc-grch38.xg",
-        orthanq_input=get_orthanq_input
-    output: "results/orthanq/preprocess/{sample}_{hla}/{sample}_{hla}.bcf",
+        orthanq_input=get_orthanq_input,
+    output:
+        "results/orthanq/preprocess/{sample}_{hla}/{sample}_{hla}.bcf",
     log:
         "logs/preprocess/{sample}_{hla}.log",
     conda:
         "../envs/orthanq.yaml"
-    params: 
+    params:
         bwa_idx_prefix=lambda wc, input: os.path.splitext(input.bwa_index[0])[0],
         output_folder=lambda wc, output: os.path.dirname(output[0]),
-        input_params=get_orthanq_input_params
+        input_params=get_orthanq_input_params,
     threads: config["threads"]
-    benchmark:    
-        "benchmarks/orthanq_preprocess/{sample}_{hla}.tsv" 
+    benchmark:
+        "benchmarks/orthanq_preprocess/{sample}_{hla}.tsv"
     shell:
         "orthanq preprocess hla --genome {input.genome} --bwa-index {params.bwa_idx_prefix} --haplotype-variants {input.candidate_variants} --vg-index {input.pangenome} --output {output} {params.input_params} --threads {threads} 2> {log}"
+
 
 # #wrappers should be used once they are ready
 rule quantify:
@@ -54,16 +57,16 @@ rule quantify:
         final_solutions="results/orthanq/calls/{sample}_{hla}/final_solution.json",
         lp_solution="results/orthanq/calls/{sample}_{hla}/lp_solution.json",
         two_field_table="results/orthanq/calls/{sample}_{hla}/2-field.csv",
-        g_groups="results/orthanq/calls/{sample}_{hla}/G_groups.csv"
+        g_groups="results/orthanq/calls/{sample}_{hla}/G_groups.csv",
     log:
-        "logs/orthanq_call/{sample}_{hla}.log"
+        "logs/orthanq_call/{sample}_{hla}.log",
     conda:
         "../envs/orthanq.yaml"
     params:
-        prior=config["orthanq_prior"]
-    resources: 
-        mem_mb=5000
-    benchmark:    
+        prior=config["orthanq_prior"],
+    resources:
+        mem_mb=5000,
+    benchmark:
         "benchmarks/orthanq_quantify/{sample}_{hla}.tsv"
     shell:
         "orthanq call hla --extend-haplotypes --num-extend-haplotypes 3 --haplotype-variants {input.haplotype_variants} --xml {input.xml} "

--- a/workflow/rules/orthanq.smk
+++ b/workflow/rules/orthanq.smk
@@ -25,7 +25,7 @@ rule preprocess:
         genome=genome,
         genome_fai=genome_fai,
         pangenome="results/preparation/hprc-v1.0-mc-grch38.xg",
-        reads=get_fastq_input
+        orthanq_input=get_orthanq_input
     output: "results/orthanq/preprocess/{sample}_{hla}/{sample}_{hla}.bcf",
     log:
         "logs/preprocess/{sample}_{hla}.log",
@@ -33,12 +33,13 @@ rule preprocess:
         "../envs/orthanq.yaml"
     params: 
         bwa_idx_prefix=lambda wc, input: os.path.splitext(input.bwa_index[0])[0],
-        output_folder=lambda wc, output: os.path.dirname(output[0])
+        output_folder=lambda wc, output: os.path.dirname(output[0]),
+        input_params=get_orthanq_input_params
     threads: config["threads"]
     benchmark:    
         "benchmarks/orthanq_preprocess/{sample}_{hla}.tsv" 
     shell:
-        "orthanq preprocess hla --genome {input.genome} --bwa-index {params.bwa_idx_prefix} --haplotype-variants {input.candidate_variants} --vg-index {input.pangenome} --output {output} --reads {input.reads[0]} {input.reads[1]} --threads {threads} 2> {log}"
+        "orthanq preprocess hla --genome {input.genome} --bwa-index {params.bwa_idx_prefix} --haplotype-variants {input.candidate_variants} --vg-index {input.pangenome} --output {output} {params.input_params} --threads {threads} 2> {log}"
 
 # #wrappers should be used once they are ready
 rule quantify:

--- a/workflow/rules/preparation.smk
+++ b/workflow/rules/preparation.smk
@@ -13,6 +13,7 @@ rule get_genome:
     wrapper:
         "v2.3.2/bio/reference/ensembl-sequence"
 
+
 rule genome_faidx:
     input:
         genome,
@@ -24,48 +25,60 @@ rule genome_faidx:
     wrapper:
         "v2.3.2/bio/samtools/faidx"
 
+
 rule get_hla_genes_and_xml:
     output:
         genes="results/preparation/hla_gen.fasta",
-        xml="results/preparation/hla.xml.zip"
+        xml="results/preparation/hla.xml.zip",
     log:
-        "logs/get_hla_genes_and_xml.log"
-    params: 
+        "logs/get_hla_genes_and_xml.log",
+    params:
         genes_link="ftp://ftp.ebi.ac.uk/pub/databases/ipd/imgt/hla/hla_gen.fasta",
-        xml_link="ftp://ftp.ebi.ac.uk/pub/databases/ipd/imgt/hla/xml/hla.xml.zip"
+        xml_link="ftp://ftp.ebi.ac.uk/pub/databases/ipd/imgt/hla/xml/hla.xml.zip",
     shell:
         "wget -c  {params.genes_link} -O {output.genes} && "
         "wget -c {params.xml_link} -O {output.xml} 2> {log}"
 
+
 rule unzip_xml:
-    input: "results/preparation/hla.xml.zip"
-    output: xml="results/preparation/hla.xml"
-    log: "logs/unzip_xml.log"
-    params: path_to_unzip=lambda wc, output: os.path.dirname(output.xml)
-    shell: 
+    input:
+        "results/preparation/hla.xml.zip",
+    output:
+        xml="results/preparation/hla.xml",
+    log:
+        "logs/unzip_xml.log",
+    params:
+        path_to_unzip=lambda wc, output: os.path.dirname(output.xml),
+    shell:
         "unzip -o {input} -d {params.path_to_unzip}"
 
+
 rule get_allele_frequencies:
-    output: 
+    output:
         rda="results/preparation/allele_frequencies.rda",
-        csv="results/preparation/allele_frequencies.csv"
+        csv="results/preparation/allele_frequencies.csv",
     conda:
         "../envs/R.yaml"
-    log: "logs/get_allele_frequencies.log"
+    log:
+        "logs/get_allele_frequencies.log",
     params:
-        data_link="https://github.com/Genentech/midasHLA/blob/11bde30cbbf11b34f2dea29a6284371a9c1e9440/data/allele_frequencies.rda?raw=true"
+        data_link="https://github.com/Genentech/midasHLA/blob/11bde30cbbf11b34f2dea29a6284371a9c1e9440/data/allele_frequencies.rda?raw=true",
     shell:
         """
         Rscript -e 'download.file("{params.data_link}", "{output.rda}"); load("{output.rda}"); write.csv(allele_frequencies, file="{output.csv}")' 2> {log}
         """
 
+
 rule get_pangenome:
-    output: "results/preparation/hprc-v1.0-mc-grch38.xg"
-    log: "logs/get_pangenome.log"
-    params: 
-        data_link="https://s3-us-west-2.amazonaws.com/human-pangenomics/pangenomes/freeze/freeze1/minigraph-cactus/hprc-v1.0-mc-grch38.xg"
+    output:
+        "results/preparation/hprc-v1.0-mc-grch38.xg",
+    log:
+        "logs/get_pangenome.log",
+    params:
+        data_link="https://s3-us-west-2.amazonaws.com/human-pangenomics/pangenomes/freeze/freeze1/minigraph-cactus/hprc-v1.0-mc-grch38.xg",
     shell:
         "wget -c {params.data_link} -O {output} 2> {log}"
+
 
 rule bwa_index:
     input:


### PR DESCRIPTION
- Use BAM inputs if available, otherwise fallback to FASTQ inputs.
- Allow HLA alleles to be specified in the config file.