### PR TITLE
fix: bad param for rule create_graph_symlink

### DIFF
--- a/workflow/rules/orthanq.smk
+++ b/workflow/rules/orthanq.smk
@@ -26,7 +26,7 @@ rule create_graph_symlink:
     output:
         "results/preparation/linked_graphs/{sample}_{hla}/hprc-v1.0-mc-grch38.xg",
     params:
-        target_dir=subpath(output, parent=True),
+        target_dir=subpath(output[0], parent=True),
     log:
         "logs/link_graph/{sample}_{hla}.log",
     shell:


### PR DESCRIPTION
I made a mistake in my earlier PR (#8 ): The param has to be changed for the `subpath` to function. I changed the rule before committing and did not notice the problem because all output files for that rule were present already.