### PR TITLE
fix: add original graph to input

### DIFF
--- a/workflow/rules/orthanq.smk
+++ b/workflow/rules/orthanq.smk
@@ -42,6 +42,7 @@ rule preprocess:
         candidate_variants="results/orthanq/candidate_variants/{hla}.vcf",
         genome=genome,
         genome_fai=genome_fai,
+        pangenome_orig="results/preparation/hprc-v1.0-mc-grch38.xg",
         pangenome="results/preparation/linked_graphs/{sample}_{hla}/hprc-v1.0-mc-grch38.xg",
         orthanq_input=get_orthanq_input,
     output:
@@ -82,7 +83,8 @@ rule quantify:
     params:
         prior=config["orthanq_prior"],
     resources:
-        mem_mb=5000,
+        mem_mb=lambda wildcards, attempt: 8000 * (2 ** (attempt - 1)),
+    retries: 3
     benchmark:
         "benchmarks/orthanq_quantify/{sample}_{hla}.tsv"
     shell:


### PR DESCRIPTION
In a previous PR, we created individual symlinks for the input pangenome graph for each instance of the `preprocess` rule because `vg` creates auxiliary files relative to the given input graph. This causes race conditions between multiple parallel instances of this rule. This solution does not work in a slurm environment because only the symlink but not the graph itself is copied to local nodes. The PR adds the original graph to the input of `preprocess` to keep the symlink intact. This induces much more network traffic. However, it can be kept low by the use of job grouping, as multiple jobs of `preprocess` can still share the same graph file - only the symlinks are individual.

As a byproduct, I adjusted the memory resources of `quantify` because some instances used huge amounts of memory and kept being killed by the slurm scheduler.